### PR TITLE
#49 - pybase image "broken C tool chain..." on python 3.4 numpy install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM eltonlaw/pybase
 
 COPY ./requirements /impyute/requirements
 RUN pip2.7 install -r /impyute/requirements/dev.txt && \
-    pip3.4 install -r /impyute/requirements/dev.txt && \
     pip3.5 install -r /impyute/requirements/dev.txt && \
     pip3.6 install -r /impyute/requirements/dev.txt && \
     pip3.7 install -r /impyute/requirements/dev.txt
@@ -13,7 +12,6 @@ COPY ./test/ /impyute/test
 COPY ./impyute /impyute/impyute
 WORKDIR /impyute
 RUN pip2.7 install -e . && \
-    pip3.4 install -e . && \
     pip3.5 install -e . && \
     pip3.6 install -e . && \
     pip3.7 install -e .

--- a/Dockerfile.pybase
+++ b/Dockerfile.pybase
@@ -8,7 +8,6 @@ RUN apt-get update && \
 
 RUN apt-get -y install \
     python2.7 python2.7-dev \
-    python3.4 python3.4-dev \
     python3.5 python3.5-dev \
     python3.6 python3.6-dev \
     python3.7 python3.7-dev && \
@@ -17,7 +16,6 @@ RUN apt-get -y install \
 RUN apt-get install wget && \
     wget https://bootstrap.pypa.io/get-pip.py && \
     python2.7 get-pip.py && \
-    python3.4 get-pip.py && \
     python3.5 get-pip.py && \
     python3.6 get-pip.py && \
     python3.7 get-pip.py && \
@@ -25,7 +23,6 @@ RUN apt-get install wget && \
     apt-get autoclean
 
 RUN python2.7 -m pip install --upgrade pip && \
-    python3.4 -m pip install --upgrade pip && \
     python3.5 -m pip install --upgrade pip && \
     python3.6 -m pip install --upgrade pip && \
     python3.7 -m pip install --upgrade pip

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,16 @@ DOCKER_ID_USER=eltonlaw
 
 all: test
 
+rebuild-pybase:
+	docker rmi $(DOCKER_ID_USER)/pybase
+	docker build -f Dockerfile.pybase -t $(DOCKER_ID_USER)/pybase .
+
 build:
-	docker pull eltonlaw/pybase
+	docker pull $(DOCKER_ID_USER)/pybase
 	docker build -t impyute .
 
 test: build
 	docker run impyute python2.7 -m pytest
-	docker run impyute python3.4 -m pytest
 	docker run impyute python3.5 -m pytest
 	docker run impyute python3.6 -m pytest
 	docker run impyute python3.7 -m pytest
@@ -28,6 +31,6 @@ docs:
 	cd docs && $(MAKE) html
 
 # Remember to call `docker login` first
-push_pybase:
+push-pybase:
 	docker build -t $(DOCKER_ID_USER)/pybase -f Dockerfile.pybase .
 	docker push $(DOCKER_ID_USER)/pybase


### PR DESCRIPTION
Removes python 3.4 from pybase and from unit tests

Fixes #49 