### PR TITLE
Feature/change test layout

### DIFF
--- a/impyute/dataset/__init__.py
+++ b/impyute/dataset/__init__.py
@@ -1,7 +1,6 @@
 """ Real-world/mock datasets and missingness corruptors to experiment with.  """
 from .base import randu
 from .base import randn
-from .base import test_data
 from .base import mnist
 
-__all__ = ["randu", "randn", "test_data", "mnist"]
+__all__ = ["randu", "randn", "mnist"]

--- a/impyute/dataset/base.py
+++ b/impyute/dataset/base.py
@@ -66,20 +66,6 @@ def randn(theta=(0, 1), shape=(5, 5), missingness="mcar", thr=0.2, dtype="float"
     return raw_data
 
 
-def test_data(mask=np.zeros((3, 3), dtype=bool)):
-    """ Returns a dataset to use with tests (INTERNAL USE - FOR UNIT TESTING)
-
-    mask: True/False array, same size as dataset
-        Use True where missing values should occur and False everywhere else
-    th: float between[0,1]
-        Percentage of missing data in generated dataset
-    """
-    shape = np.shape(mask)
-    data = np.reshape(np.arange(np.product(shape)), shape).astype("float")
-    data[mask] = np.nan
-    return data
-
-
 def mnist(missingness="mcar", thr=0.2):
     """ Loads corrupted MNIST
 

--- a/impyute/util/testing.py
+++ b/impyute/util/testing.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+
+def return_na_check(data):
+    """Helper function for tests to check if the data returned is a
+       numpy array and that the imputed data has no NaN's.
+
+    Parameters
+    ----------
+    data: numpy.ndarray
+        Data to impute.
+    
+    Returns
+    -------
+    None
+
+    """
+    assert isinstance(data, np.ndarray)
+    assert not np.isnan(data).any()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore::RuntimeWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 filterwarnings =
     ignore::RuntimeWarning
+    ignore::FutureWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
 filterwarnings =
     ignore::RuntimeWarning
-    ignore::FutureWarning

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,5 @@
+import os
 import shutil
-from pathlib import Path
 
 import pytest
 import numpy as np
@@ -43,8 +43,8 @@ def mw_data():
 @pytest.fixture(scope='session')
 def results_path(tmpdir_factory):
     temp = tmpdir_factory.mktemp('logs')
-    p = Path(temp).resolve()
-    log_path = p / 'results.txt'
+    p = os.path.realpath(temp)
+    log_path = os.path.join(p, 'results.txt')
     yield log_path
     if temp.exists():
         shutil.rmtree(str(temp))

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -43,7 +43,7 @@ def mw_data():
 @pytest.fixture(scope='session')
 def results_path(tmpdir_factory):
     temp = tmpdir_factory.mktemp('logs')
-    p = os.path.realpath(temp)
+    p = os.path.realpath(str(temp))
     log_path = os.path.join(p, 'results.txt')
     yield log_path
     if temp.exists():

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,50 @@
+import shutil
+from pathlib import Path
+
+import pytest
+import numpy as np
+
+
+@pytest.fixture(scope='function')
+def test_data():
+    def prepare_data(shape=(3, 3), pos1=0, pos2=0):
+        data = np.reshape(np.arange(np.product(shape)), shape).astype("float")
+        data[pos1, pos2] = np.nan
+        return data
+    return prepare_data
+
+
+@pytest.fixture(scope='session')
+def buck_test_data():
+    data = np.asarray([[1, 2, 3, 4, 5, 6, 7, 8],
+                   [1, 4, 6, 8, 10, 12, 14, 16],
+                   [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4],
+                   [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4],
+                   [3, 6, 9, 12, 15, 18, 21, 24],
+                   [4, 8, 9, 16, 20, 24, 28, 32]])
+    data[0, 0] = np.nan
+    return data
+
+
+@pytest.fixture(scope='session')
+def knn_test_data():
+    n = 100
+    data = np.random.normal(size=n * n).reshape((n, n))
+    for _ in range(int(n * 0.3 * n)):
+        data[np.random.randint(n), np.random.randint(n)] = np.nan
+    return data
+
+
+@pytest.fixture(scope='function')
+def mw_data():
+    return np.arange(0, 25).reshape(5, 5).astype(float)
+
+
+@pytest.fixture(scope='session')
+def results_path(tmpdir_factory):
+    temp = tmpdir_factory.mktemp('logs')
+    p = Path(temp).resolve()
+    log_path = p / 'results.txt'
+    yield log_path
+    if temp.exists():
+        shutil.rmtree(str(temp))

--- a/test/deletion/test_complete_case.py
+++ b/test/deletion/test_complete_case.py
@@ -1,35 +1,25 @@
 """test_complete_case.py"""
 import numpy as np
-from impyute.dataset import test_data
 from impyute.deletion import complete_case
+from impyute.util.testing import return_na_check
 
-mask = np.zeros((5, 5), dtype=bool)
-data_c = test_data(mask)
-mask[0][0] = True
-data_m = test_data(mask)
+SHAPE = (5, 5)
 
-def test_return_type():
-    """ Check return type, should return an np.ndarray"""
-    imputed = complete_case(data_m)
-    assert isinstance(imputed, np.ndarray)
 
-def test_impute_no_missing_values():
-    """ After imputation, no change should occur"""
-    imputed = complete_case(data_m)
-    assert not np.isnan(imputed).any()
+def test_complete_case_(test_data):
+    data = test_data(SHAPE)
+    imputed = complete_case(data)
+    return_na_check(imputed)
 
-def test_impute_missing_values():
-    """ After imputation, no NaN's should exist"""
-    imputed = complete_case(data_m)
+
+def test_impute_missing_values(test_data):
+    data = test_data(SHAPE)
+    imputed = complete_case(data)
     assert np.shape(imputed) == (4, 5)
 
-def test_imputed_values():
-    """ Assert values are as expected"""
-    imputed = complete_case(data_m)
-    expected = np.array([
-        [5., 6., 7., 8., 9.],
-        [10., 11., 12., 13., 14.],
-        [15., 16., 17., 18., 19.],
-        [20., 21., 22., 23., 24.]
-    ])
+
+def test_imputed_values(test_data):
+    data = test_data(SHAPE)
+    imputed = complete_case(data)
+    expected = np.arange(5, 25, dtype=float).reshape(4, 5)
     assert np.equal(imputed, expected).all()

--- a/test/imputation/cs/test_buck_iterative.py
+++ b/test/imputation/cs/test_buck_iterative.py
@@ -1,24 +1,8 @@
 """test_buck_iterative.py"""
-import numpy as np
 import impyute as impy
+from impyute.util.testing import return_na_check
 
-data = np.asarray([[1, 2, 3, 4, 5, 6, 7, 8],
-                   [1, 4, 6, 8, 10, 12, 14, 16],
-                   [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4],
-                   [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4],
-                   [3, 6, 9, 12, 15, 18, 21, 24],
-                   [4, 8, 9, 16, 20, 24, 28, 32]])
-mask = np.zeros((6, 8), dtype=bool)
-data_c = data[mask]
-data[0][0] = np.nan
-data_m = data
 
-def test_return_type():
-    """ Check return type, should return an np.ndarray"""
-    imputed = impy.buck_iterative(data_m)
-    assert isinstance(imputed, np.ndarray)
-
-def test_impute_missing_values():
-    """ After imputation, no NaN's should exist"""
-    imputed = impy.buck_iterative(data_m)
-    assert not np.isnan(imputed).any()
+def test_buck_iter(buck_test_data):
+    imputed = impy.buck_iterative(buck_test_data)
+    return_na_check(imputed)

--- a/test/imputation/cs/test_central_tendency.py
+++ b/test/imputation/cs/test_central_tendency.py
@@ -1,38 +1,23 @@
 """test_averagings.py"""
-import numpy as np
 import impyute as impy
+from impyute.util.testing import return_na_check
 
-mask = np.zeros((5, 5), dtype=bool)
-data_c = impy.dataset.test_data(mask=mask)
-mask[0][0] = True
-data_m = impy.dataset.test_data(mask=mask)
+SHAPE = (5, 5)
 
-def test_mean_return_type():
-    """ Check return type, should return an np.ndarray"""
-    imputed = impy.mode(data_m)
-    assert isinstance(imputed, np.ndarray)
 
-def test_mode_return_type():
-    """ Check return type, should return an np.ndarray"""
-    imputed = impy.mode(data_m)
-    assert isinstance(imputed, np.ndarray)
+def test_mean(test_data):
+    data = test_data(SHAPE)
+    imputed = impy.mean(data)
+    return_na_check(imputed)
 
-def test_median_return_type():
-    """ Check return type, should return an np.ndarray"""
-    imputed = impy.mode(data_m)
-    assert isinstance(imputed, np.ndarray)
 
-def test_mean_impute_missing_values():
-    """ After imputation, no Nan's should exist"""
-    imputed = impy.mean(data_m)
-    assert not np.isnan(imputed).any()
+def test_mode(test_data):
+    data = test_data(SHAPE)
+    imputed = impy.mode(data)
+    return_na_check(imputed)
 
-def test_mode_impute_missing_values():
-    """ After imputation, no NaN's should exist"""
-    imputed = impy.mode(data_m)
-    assert not np.isnan(imputed).any()
 
-def test_median_impute_missing_values():
-    """ After imputation, no NaN's should exist"""
-    imputed = impy.median(data_m)
-    assert not np.isnan(imputed).any()
+def test_median(test_data):
+    data = test_data(SHAPE)
+    imputed = impy.median(data)
+    return_na_check(imputed)

--- a/test/imputation/cs/test_em.py
+++ b/test/imputation/cs/test_em.py
@@ -1,18 +1,11 @@
 """test_em.py"""
-import numpy as np
 import impyute as impy
+from impyute.util.testing import return_na_check
 
-mask = np.zeros((5, 5), dtype=bool)
-data_c = impy.dataset.test_data(mask=mask)
-mask[0][0] = True
-data_m = impy.dataset.test_data(mask=mask)
+SHAPE = (5, 5)
 
-def test_return_type():
-    """ Check return type, should return an np.ndarray"""
-    imputed = impy.em(data_m)
-    assert isinstance(imputed, np.ndarray)
 
-def test_impute_missing_values():
-    """ After imputation, no NaN's should exist"""
-    imputed = impy.em(data_m)
-    assert not np.isnan(imputed).any()
+def test_em_(test_data):
+    data = test_data(SHAPE)
+    imputed = impy.em(data)
+    return_na_check(imputed)

--- a/test/imputation/cs/test_fast_knn.py
+++ b/test/imputation/cs/test_fast_knn.py
@@ -2,37 +2,27 @@
 import functools
 import numpy as np
 import impyute as impy
+from impyute.util.testing import return_na_check
 # pylint:disable=invalid-name
 
-n = 100
-data_c = np.random.normal(size=n*n).reshape((n, n))
-data_m1 = data_c.copy()
-for _ in range(int(n*0.3*n)):
-    data_m1[np.random.randint(n)][np.random.randint(n)] = np.nan
+SHAPE = (5, 5)
 
-def test_return_type():
-    """ Check return type, should return an np.ndarray"""
-    imputed = impy.fast_knn(data_m1)
-    assert isinstance(imputed, np.ndarray)
 
-def test_impute_missing_values():
-    """ After imputation, no NaN's should exist"""
-    imputed = impy.fast_knn(data_m1)
-    assert not np.isnan(imputed).any()
+def test_return_type(knn_test_data):
+    imputed = impy.fast_knn(knn_test_data)
+    return_na_check(imputed)
 
-data_m2 = np.array([[0., 1., np.nan, 3., 4.],
-                    [5., 6., 7., 8., 9.],
-                    [10., 11., 12., 13., 14.],
-                    [15., 16., 17., 18., 19.],
-                    [20., 21., 22., 23., 24.]])
 
-def test_impute_value():
+def test_impute_value(test_data):
     "fast_knn using standard idw"
-    imputed = impy.fast_knn(data_m2, k=2)
-    assert np.isclose(imputed[0][2], 8.38888888888889)
+    data = test_data(SHAPE, 0, 2)
+    imputed = impy.fast_knn(data, k=2)
+    assert np.isclose(imputed[0, 2], 8.38888888888889)
 
-def test_impute_value_custom_idw():
+
+def test_impute_value_custom_idw(test_data):
     "fast_knn using custom idw"
+    data = test_data(SHAPE, 0, 2)
     idw = functools.partial(impy.util.inverse_distance_weighting.shepards, power=1)
-    imputed = impy.fast_knn(data_m2, k=2, idw=idw)
-    assert np.isclose(imputed[0][2], 8.913911092686593)
+    imputed = impy.fast_knn(data, k=2, idw=idw)
+    assert np.isclose(imputed[0, 2], 8.913911092686593)

--- a/test/imputation/cs/test_random.py
+++ b/test/imputation/cs/test_random.py
@@ -1,18 +1,11 @@
 """test_random_imputation.py"""
-import numpy as np
 import impyute as impy
+from impyute.util.testing import return_na_check
 
-mask = np.zeros((3, 3), dtype=bool)
-data_c = impy.dataset.test_data(mask=mask)
-mask[0][0] = True
-data_m = impy.dataset.test_data(mask=mask)
+SHAPE = (3, 3)
 
-def test_return_type():
-    """Check return type, should return an np.ndarray"""
-    imputed = impy.random(data_m)
-    assert isinstance(imputed, np.ndarray)
 
-def test_impute_missing_values():
-    """After imputation, no NaN's should exist"""
-    imputed = impy.random(data_m)
-    assert not np.isnan(imputed).any()
+def test_random_(test_data):
+    data = test_data(SHAPE)
+    imputed = impy.random(data)
+    return_na_check(imputed)

--- a/test/imputation/ts/test_locf.py
+++ b/test/imputation/ts/test_locf.py
@@ -1,53 +1,35 @@
 """test_locf.py"""
-import unittest
 import numpy as np
 import impyute as impy
+from impyute.util.testing import return_na_check
+
+SHAPE = (5, 5)
 
 
-class TestLOCF(unittest.TestCase):
-    """ Tests for Last Observation Carried Forward """
-    def setUp(self):
-        """
-        self.data_c: Complete dataset/No missing values
-        self.data_m: Incommplete dataset/Has missing values
-        """
-        mask = np.zeros((5, 5), dtype=bool)
-        self.data_c = impy.dataset.test_data(mask=mask)
-        mask[0][0] = True
-        self.data_m = impy.dataset.test_data(mask=mask)
-
-    def test_impute_missing_values(self):
-        """ After imputation, no NaN's should exist"""
-        imputed = impy.locf(self.data_m)
-        self.assertFalse(np.isnan(imputed).any())
-
-    def test_return_type(self):
-        """ Check return type, should return an np.ndarray"""
-        imputed = impy.locf(self.data_m)
-        self.assertTrue(isinstance(imputed, np.ndarray))
-
-    def test_na_at_i_start(self):
-        """Check if null value at a row[0],column[0]=row[1],column[0]"""
-        self.data_c[0][0] = np.nan
-        actual = impy.locf(self.data_c, axis=1)
-        self.data_c[0][0] = self.data_c[1][0]
-        self.assertTrue(np.array_equal(actual, self.data_c))
-
-    def test_na_at_i(self):
-        """Check if a null row[i],column[j]=row[i-1],column[j]"""
-        self.data_c[3][3] = np.nan
-        actual = impy.locf(self.data_c, axis=1)
-        self.data_c[3][3] = self.data_c[2][3]
-        self.assertTrue(np.array_equal(actual, self.data_c))
-
-    def test_na_at_i_end(self):
-        """Check if at row[last_i],column[i]=row[last_i-1],column[i]"""
-        last_i = np.shape(self.data_c)[0]-1
-        self.data_c[last_i][3] = np.nan
-        actual = impy.locf(self.data_c, axis=1)
-        self.data_c[last_i][3] = self.data_c[last_i-1][3]
-        self.assertTrue(np.array_equal(actual, self.data_c))
+def test_locf_(test_data):
+    data = test_data(SHAPE)
+    imputed = impy.locf(data)
+    return_na_check(imputed)
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_na_at_i_start(test_data):
+    data = test_data(SHAPE)
+    actual = impy.locf(data, axis=1)
+    data[0, 0] = data[1, 0]
+    assert np.array_equal(actual, data)
+
+
+def test_na_at_i(test_data):
+    data = test_data(SHAPE, 3, 3)
+    actual = impy.locf(data, axis=1)
+    data[3, 3] = data[2, 3]
+    assert np.array_equal(actual, data)
+
+
+def test_na_at_i_end(test_data):
+    data = test_data(SHAPE)
+    last_i = np.shape(data)[0] - 1
+    data = test_data(SHAPE, last_i, 3)
+    actual = impy.locf(data, axis=1)
+    data[last_i, 3] = data[last_i - 1, 3]
+    assert np.array_equal(actual, data)

--- a/test/imputation/ts/test_moving_window.py
+++ b/test/imputation/ts/test_moving_window.py
@@ -2,68 +2,59 @@
 import pytest
 import numpy as np
 import impyute as impy
+from impyute.util.testing import return_na_check
 #pylint:disable=missing-docstring, redefined-outer-name
 
-@pytest.fixture
-def data():
-    return np.arange(0, 25).reshape(5, 5).astype(float)
 
-def test_defaults_impute_leftmost_index(data):
-    data[2][0] = np.nan
-    imputed = impy.moving_window(data)
-    assert not np.isnan(imputed).any()
-    assert imputed[2][0] == 11.5
+@pytest.mark.parametrize(
+    'pos1,pos2,expected',
+    [
+        (2, 0, 11.5),
+        (2, 2, 12),
+        (2, -1, 12.5)]
+    )
+def test_defaults_impute(pos1, pos2, expected, mw_data):
+    mw_data[pos1, pos2] = np.nan
+    imputed = impy.moving_window(mw_data)
+    return_na_check(imputed)
+    assert imputed[pos1, pos2] == expected
 
-def test_defaults_impute_middle_index(data):
-    data[2][2] = np.nan
-    imputed = impy.moving_window(data)
-    assert not np.isnan(imputed).any()
-    assert imputed[2][2] == 12
 
-def test_defaults_impute_rightmost_index(data):
-    data[2][-1] = np.nan
-    imputed = impy.moving_window(data)
-    assert not np.isnan(imputed).any()
-    assert imputed[2][-1] == 12.5
+@pytest.mark.parametrize(
+    'pos1,pos2,expected',
+    [
+        (2, 0, 24),
+        (2, 2, 28),
+        (2, -1, 26)]
+    )
+def test_custom_fn_impute(pos1, pos2, expected, mw_data):
+    mw_data[pos1, pos2] = np.nan
+    imputed = impy.moving_window(mw_data, func=lambda l: max(l) * 2)
+    return_na_check(imputed)
+    assert imputed[pos1, pos2] == expected
 
-def test_custom_fn_impute_leftmost_index(data):
-    data[2][0] = np.nan
-    imputed = impy.moving_window(data, func=lambda l: max(l) * 2)
-    assert not np.isnan(imputed).any()
-    assert imputed[2][0] == 24
 
-def test_custom_fn_impute_middle_index(data):
-    data[2][2] = np.nan
-    imputed = impy.moving_window(data, func=lambda l: max(l) * 2)
-    assert not np.isnan(imputed).any()
-    assert imputed[2][2] == 28
+@pytest.mark.parametrize(
+    'pos1,pos2,expected',
+    [
+        (2, 0, 12.5),
+        (2, -1, 12.5)]
+    )
+def test_custom_nindex_impute_0(pos1, pos2, expected, mw_data):
+    mw_data[pos1, pos2] = np.nan
+    imputed = impy.moving_window(mw_data, nindex=0)
+    return_na_check(imputed)
+    assert imputed[pos1, pos2] == expected
 
-def test_custom_fn_impute_rightmost_index(data):
-    data[2][-1] = np.nan
-    imputed = impy.moving_window(data, func=lambda l: max(l) * 2)
-    assert not np.isnan(imputed).any()
-    assert imputed[2][-1] == 26
 
-def test_custom_nindex_impute_leftmost_index_falls_off(data):
-    data[2][0] = np.nan
-    imputed = impy.moving_window(data, nindex=-1)
-    assert not np.isnan(imputed).any()
-    assert imputed[2][0] == 11.5
-
-def test_custom_nindex_impute_rightmost_valid(data):
-    data[2][0] = np.nan
-    imputed = impy.moving_window(data, nindex=0)
-    assert not np.isnan(imputed).any()
-    assert imputed[2][0] == 12.5
-
-def test_custom_nindex_impute_leftmost_falls_off(data):
-    data[2][-1] = np.nan
-    imputed = impy.moving_window(data, nindex=0)
-    assert not np.isnan(imputed).any()
-    assert imputed[2][-1] == 12.5
-
-def test_custom_nindex_impute_rightmost_index_valid(data):
-    data[2][-1] = np.nan
-    imputed = impy.moving_window(data, nindex=-1)
-    assert not np.isnan(imputed).any()
-    assert imputed[2][-1] == 11.5
+@pytest.mark.parametrize(
+    'pos1,pos2,expected',
+    [
+        (2, 0, 11.5),
+        (2, -1, 11.5)]
+    )
+def test_custom_nindex_impute_1(pos1, pos2, expected, mw_data):
+    mw_data[pos1, pos2] = np.nan
+    imputed = impy.moving_window(mw_data, nindex=-1)
+    return_na_check(imputed)
+    assert imputed[pos1, pos2] == expected

--- a/test/util/test_checks.py
+++ b/test/util/test_checks.py
@@ -4,10 +4,12 @@ import numpy as np
 from impyute.util import BadInputError
 from impyute.util import checks
 
+
 @checks
 def some_fn(data):
     """Dummy fn that has form of np.array -> np.array"""
     return data
+
 
 def test_correct_input():
     """ Test that an array that should satisfy all checks, no BadInputError should be raised"""
@@ -20,6 +22,7 @@ def test_correct_input():
     except BadInputError:
         assert False
 
+
 def test_1d():
     """ Check 1d array, BadInputError raised"""
     arr = np.array([np.nan, 2])
@@ -27,11 +30,13 @@ def test_1d():
         some_fn(arr)
     assert str(excinfo.value) == "No support for arrays that aren't 2D yet."
 
+
 def test_not_nparray():
     """ If not an np.array, BadInputError raised"""
     with pytest.raises(BadInputError) as excinfo:
         some_fn([[np.nan, 2.], [3, 4]])
     assert str(excinfo.value) == "Not a np.ndarray."
+
 
 def test_nan_exists():
     """ If no NaN, BadInputError raised"""

--- a/test/util/test_compare.py
+++ b/test/util/test_compare.py
@@ -1,4 +1,5 @@
 """test_compare.py"""
+import ast
 import numpy as np
 import impyute as impy
 
@@ -14,5 +15,5 @@ def test_output_file_exists(test_data, results_path):
 
     impy.util.compare(imputed_mode, log_path=results_path)
     with open(results_path, 'r') as fin:
-        expected = "{'mode': [('SVC', 0.0)], 'mean': [('SVC', 0.0)]}"
-        assert next(fin) == expected
+        expected = {'mode': [('SVC', 0.0)], 'mean': [('SVC', 0.0)]}
+        assert ast.literal_eval(next(fin)) == expected

--- a/test/util/test_compare.py
+++ b/test/util/test_compare.py
@@ -2,15 +2,17 @@
 import numpy as np
 import impyute as impy
 
-mask = np.zeros((5, 5), dtype=bool)
-mask[0][0] = True
-data_m = impy.dataset.test_data(mask=mask)
-labels = np.array([1, 0, 1, 1, 0])
-imputed_mode = []
-imputed_mode.append(["mode", (impy.mode(np.copy(data_m)), labels)])
-imputed_mode.append(["mean", (impy.mean(np.copy(data_m)), labels)])
+SHAPE = (5, 5)
 
-def test_output_file_exists():
-    """ Small test to just check that it runs without fialing"""
-    path = "./results.txt"
-    impy.util.compare(imputed_mode, log_path=path)
+
+def test_output_file_exists(test_data, results_path):
+    data = test_data(SHAPE)
+    labels = np.array([1, 0, 1, 1, 0])
+    imputed_mode = []
+    imputed_mode.append(["mode", (impy.mode(np.copy(data)), labels)])
+    imputed_mode.append(["mean", (impy.mean(np.copy(data)), labels)])
+
+    impy.util.compare(imputed_mode, log_path=results_path)
+    with open(results_path, 'r') as fin:
+        expected = "{'mode': [('SVC', 0.0)], 'mean': [('SVC', 0.0)]}"
+        assert next(fin) == expected

--- a/test/util/test_compare.py
+++ b/test/util/test_compare.py
@@ -1,5 +1,6 @@
 """test_compare.py"""
 import ast
+import pytest
 import numpy as np
 import impyute as impy
 

--- a/test/util/test_compare.py
+++ b/test/util/test_compare.py
@@ -6,6 +6,7 @@ import impyute as impy
 SHAPE = (5, 5)
 
 
+@pytest.mark.filterwarnings('ignore::FutureWarning')
 def test_output_file_exists(test_data, results_path):
     data = test_data(SHAPE)
     labels = np.array([1, 0, 1, 1, 0])

--- a/test/util/test_preprocess.py
+++ b/test/util/test_preprocess.py
@@ -73,7 +73,7 @@ def test_pandas_input():
     """ Input: DataFrame, Output: DataFrame """
     # Skip this test if you don't have pandas
     pytest.importorskip('pandas')
-
+    import pandas as pd
     # Create a DataFrame with a NaN
     A = np.arange(25).reshape((5, 5)).astype(np.float)
     A[0, 0] = np.nan

--- a/test/util/test_preprocess.py
+++ b/test/util/test_preprocess.py
@@ -20,25 +20,29 @@ def mul(arr, **kwargs):
     arr *= 25
     return arr
 
+
 @preprocess
 def mul_no_kwargs(arr):
     """Some function that performs an inplace operation on the input"""
     arr *= 25
     return arr
 
+
 def test_inplace_false():
     """Input should be unchanged if inplace set to false"""
     A = np.ones((5, 5))
     A_copy = A.copy()
     mul(A, inplace=False)
-    assert A[0][0] == A_copy[0][0]
+    assert A[0, 0] == A_copy[0, 0]
+
 
 def test_inplace_true():
     """Input may be changed if inplace set to true and operation is inplace"""
     A = np.ones((5, 5))
     A_copy = A.copy()
     mul(A, inplace=True)
-    assert A[0][0] != A_copy[0][0]
+    assert A[0, 0] != A_copy[0, 0]
+
 
 def test_inplace_false_nokwargs():
     """Test that passed in function doesn't need to set kwargs as parameters
@@ -49,7 +53,8 @@ def test_inplace_false_nokwargs():
     # pylint: disable = unexpected-keyword-arg
     mul_no_kwargs(A, inplace=False)
     # pylint: enable = unexpected-keyword-arg
-    assert A[0][0] == A_copy[0][0]
+    assert A[0, 0] == A_copy[0, 0]
+
 
 def test_inplace_true_nokwargs():
     """Test that passed in function doesn't need to set kwargs as parameters
@@ -60,7 +65,8 @@ def test_inplace_true_nokwargs():
     # pylint: disable = unexpected-keyword-arg
     mul_no_kwargs(A, inplace=True)
     # pylint: enable = unexpected-keyword-arg
-    assert A[0][0] != A_copy[0][0]
+    assert A[0, 0] != A_copy[0, 0]
+
 
 def test_pandas_input():
     """ Input: DataFrame, Output: DataFrame """
@@ -73,7 +79,7 @@ def test_pandas_input():
 
     # Create a DataFrame with a NaN
     A = np.arange(25).reshape((5, 5)).astype(np.float)
-    A[0][0] = np.nan
+    A[0, 0] = np.nan
     A = pd.DataFrame(A)
 
     # Assert that the output is a DataFrame

--- a/test/util/test_preprocess.py
+++ b/test/util/test_preprocess.py
@@ -1,4 +1,5 @@
 """test_preprocess.py"""
+import pytest
 import numpy as np
 from impyute.util import preprocess
 from impyute.imputation.cs import mean
@@ -71,11 +72,7 @@ def test_inplace_true_nokwargs():
 def test_pandas_input():
     """ Input: DataFrame, Output: DataFrame """
     # Skip this test if you don't have pandas
-    try:
-        import pandas as pd
-    except (ModuleNotFoundError, ImportError):
-        assert True
-        return
+    pytest.importorskip('pandas')
 
     # Create a DataFrame with a NaN
     A = np.arange(25).reshape((5, 5)).astype(np.float)


### PR DESCRIPTION
This addresses #80 .
1) Puts all fixtures into the `conftest.py` file as [recommended](https://docs.pytest.org/en/2.7.3/fixture.html#sharing-a-fixture-across-tests-in-a-module-or-class-session) by `pytest`.
2) Adds a `pytest.ini` file to ignore `RuntimeWarning` when running `pytest`. This comes about when running older versions of `numpy` and `sklearn`. The output of the tests remains as intended.
3) Creates a function in `impyute/util/testing.py` which does the two tasks of checking the `return_type` and `missing_value` which appeared in almost every test file.
4) Modified the tests to use these fixtures as well as other `pytest` best practices to make code more readable.
5) Fixed the `test_compare.py` test to actually test the output of the file. Previously it wrote out a file to the repo that would remain there. Now it uses `pytest` fixtures to write to a temporary directory, check the contents of the file, and then delete the file so that the user does not have to have this file hanging around their system.
6) Changed the last two remaining test files using `unittest` to use `pytest` so that testing is consistent across the whole package.