### PR TITLE
Ddfg add randc function

### DIFF
--- a/impyute/dataset/base.py
+++ b/impyute/dataset/base.py
@@ -89,7 +89,7 @@ def randc(nlevels=5, shape=(5, 5), missingness="mcar", thr=0.2):
         raise BadInputError("nlevel exceeds the size of desired dataset. Please decrease the nlevel or increase the shape")
 
     length = len(string.ascii_lowercase)
-    n_fold = math.floor(math.log(nlevels, length))
+    n_fold = int(math.floor(math.log(nlevels, length)))
     cat_pool = list(string.ascii_lowercase)
 
     # when nlevel > 26, the alphabetical character is used up, need to generate extra strings as categorical data

--- a/impyute/dataset/base.py
+++ b/impyute/dataset/base.py
@@ -75,15 +75,18 @@ def randc(nlevels=5, shape=(5, 5), missingness="mcar", thr=0.2):
 
     Parameters
     ----------
-    :param nlevels: int
+    nlevels: int
         Specify the number of different categories in the dataset
-    :param shape: tuple(optional)
+    shape: tuple(optional)
         Size of the randomly generated data
-    :param missingness: string in ('mcar', 'mar', 'mnar')
+    missingness: string in ('mcar', 'mar', 'mnar')
         Type of missingness you want in your dataset
-    :param thr: float between [0,1]
+    thr: float between [0,1]
         Percentage of missing data in generated data
-    :return:
+
+    Returns
+    -------
+    numpy.ndarray
     """
     if shape[0]*shape[1] < nlevels:
         raise BadInputError("nlevel exceeds the size of desired dataset. Please decrease the nlevel or increase the shape")

--- a/impyute/dataset/corrupt.py
+++ b/impyute/dataset/corrupt.py
@@ -9,7 +9,7 @@ class Corruptor:
     ----------
     data: np.ndarray
         Matrix of values with no NaN's that you want to add NaN's to.
-    th: float (optional)
+    thr: float (optional)
         The percentage of null values you want in your dataset, a number
         between 0 and 1.
 

--- a/impyute/dataset/corrupt.py
+++ b/impyute/dataset/corrupt.py
@@ -23,10 +23,10 @@ class Corruptor:
         Overwrite values with MNAR placed NaN's.
 
     """
-    def __init__(self, data, thr=0.2):
+    def __init__(self, data, thr=0.2, dtype=np.float):
         self.dtype = data.dtype
         self.shape = np.shape(data)
-        self.data = data.astype(np.float)
+        self.data = data.astype(dtype)
         self.thr = thr
 
     def mcar(self):

--- a/test/dataset/test_randc.py
+++ b/test/dataset/test_randc.py
@@ -1,0 +1,26 @@
+import numpy as np
+import pytest
+from impyute.dataset.base import randc
+from impyute.util import BadInputError
+
+def test_raise_error_nlevel_exceed_shape():
+    with pytest.raises(BadInputError) as e:
+        randc(shape=(2, 2))
+    expected = "nlevel exceeds the size of desired dataset. Please decrease the nlevel or increase the shape"
+    assert str(e.value) == expected
+
+@pytest.mark.parametrize("nlevels, shape", [(5, (5,5)), (9, (3,4)), (100, (20, 20))])
+def test_nlevel_categories(nlevels, shape):
+    """ideally the returned matrix should have nlevel+1 different categories, +1 because the Corrupt class introduce np.nan
+       however, if the missing value introduced by Corrupt class happens to replace a group of categories, the unique
+       category number would be < nlevel + 1
+    """
+    dataframe = randc(nlevels, shape)
+    assert len(np.unique(dataframe)) <= nlevels + 1
+
+
+@pytest.mark.parametrize("nlevels, shape", [(5, (5,5)), (9, (3, 4)), (100, (20, 20))])
+def test_dataframe_shape(nlevels, shape):
+    """test if the returned data frame has desired shape"""
+    dataframe = randc(nlevels, shape)
+    assert dataframe.shape == shape


### PR DESCRIPTION
This pull request is for addressing #67 
1. Add a function randc() to randomly generate data frame with categorical data, which are alphabetic characters. Extra characters combinations would be generated when the 26 characters are used up. (If number is desired, just leave a comment, I can update it)
2. Update the Corruptor class to accept an extra attribute `dtype` with default value `np.float`, so the Corrupter class can generate dataset in other dtype, like np.string
3. Add test cases for randc() function. One for BadInputError test, second for testing if the number of categories in the dataset is desired, third for testing if the shape of the dataset is desired.